### PR TITLE
Describe how to set up for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,10 @@ Create a root filesystem, extract it (still as root), and point to it:
 
 Install ginkgo (used to test garden):
 ```
-# cd /root/go/src/github.com/onsi/ginkgo/ginkgo
-# go install
+# go install github.com/onsi/ginkgo/ginkgo
 ```
 
 Run the tests (skipping performance measurements):
 ```
-# cd /root/go/src/github.com/pivotal-cf-experimental/garden
 # ginkgo -r -skipMeasurements
 ```


### PR DESCRIPTION
This depends on a valid Docker base image being available as
referenced by the FROM statement in integration/rootfs/Dockerfile.

The performance measurements tests give rise to some arithmetic
overflows and seem unstable and so are omitted from these
instructions.
