### PR TITLE
bump ginkgo

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -15,7 +15,7 @@
 		},
 		{
 			"ImportPath": "github.com/onsi/ginkgo",
-			"Rev": "349f2d5baae688f172db626a521c8317e11550d3"
+			"Rev": "736acf4afbc1fff096f59fb899163b602edec924"
 		},
 		{
 			"ImportPath": "github.com/onsi/gomega",

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/README.md
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/README.md
@@ -4,6 +4,8 @@
 
 Jump to the [docs](http://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
 
+To discuss Ginkgo and get updates, join the [google group](https://groups.google.com/d/forum/ginkgo-and-gomega).
+
 ## Feature List
 
 - Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](http://onsi.github.io/ginkgo/#bootstrapping_a_suite) and start writing your [first tests](http://onsi.github.io/ginkgo/#adding_specs_to_a_suite)

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/example_collection.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/example_collection.go
@@ -5,7 +5,6 @@ import (
 	"github.com/onsi/ginkgo/types"
 
 	"math/rand"
-	"os"
 	"regexp"
 	"sort"
 	"time"
@@ -20,11 +19,11 @@ type exampleCollection struct {
 	startTime                         time.Time
 	suiteID                           string
 	runningExample                    *example
-	writer                            ginkgoWriter
+	writer                            ginkgoWriterInterface
 	config                            config.GinkgoConfigType
 }
 
-func newExampleCollection(t GinkgoTestingT, description string, examples []*example, reporters []Reporter, writer ginkgoWriter, config config.GinkgoConfigType) *exampleCollection {
+func newExampleCollection(t GinkgoTestingT, description string, examples []*example, reporters []Reporter, writer ginkgoWriterInterface, config config.GinkgoConfigType) *exampleCollection {
 	collection := &exampleCollection{
 		t:           t,
 		description: description,
@@ -139,7 +138,7 @@ func (collection *exampleCollection) run() bool {
 	suiteFailed := false
 
 	for _, example := range collection.examples {
-		collection.clearWriterBuffer()
+		collection.writer.Truncate()
 
 		collection.reportExampleWillRun(example)
 
@@ -148,7 +147,7 @@ func (collection *exampleCollection) run() bool {
 			example.run()
 			if example.failed() {
 				suiteFailed = true
-				collection.printWriterToStdout()
+				collection.writer.DumpOut()
 			}
 		} else if example.pending() && collection.config.FailOnPending {
 			suiteFailed = true
@@ -169,18 +168,6 @@ func (collection *exampleCollection) run() bool {
 func (collection *exampleCollection) fail(failure failureData) {
 	if collection.runningExample != nil {
 		collection.runningExample.fail(failure)
-	}
-}
-
-func (collection *exampleCollection) clearWriterBuffer() {
-	if collection.writer != nil {
-		collection.writer.Truncate(0)
-	}
-}
-
-func (collection *exampleCollection) printWriterToStdout() {
-	if collection.writer != nil {
-		collection.writer.WriteTo(os.Stdout)
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo.go
@@ -12,7 +12,7 @@ Ginkgo is MIT-Licensed
 package ginkgo
 
 import (
-	"bytes"
+	"fmt"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/remote"
 	"github.com/onsi/ginkgo/reporters"
@@ -25,6 +25,18 @@ import (
 )
 
 const GINKGO_VERSION = config.VERSION
+const GINKGO_PANIC = `
+Your test failed.
+Ginkgo panics to prevent subsequent assertions from running.
+Normally Ginkgo rescues this panic so you shouldn't see it.
+
+But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
+To circumvent this, you should call
+
+	defer GinkgoRecover()
+
+at the top of the goroutine that caused this panic.
+`
 
 const defaultTimeout = 1
 
@@ -32,6 +44,7 @@ var globalSuite *suite
 
 func init() {
 	config.Flags("ginkgo", true)
+	GinkgoWriter = newGinkgoWriter(os.Stdout)
 	globalSuite = newSuite()
 }
 
@@ -151,14 +164,9 @@ func RunSpecsWithDefaultAndCustomReporters(t GinkgoTestingT, description string,
 //To run your tests with your custom reporter(s) (and *not* Ginkgo's default reporter), replace
 //RunSpecs() with this method.
 func RunSpecsWithCustomReporters(t GinkgoTestingT, description string, specReporters []Reporter) bool {
-	if config.DefaultReporterConfig.Verbose {
-		GinkgoWriter = os.Stdout
-		return globalSuite.run(t, description, specReporters, nil, config.GinkgoConfig)
-	} else {
-		buffer := &bytes.Buffer{}
-		GinkgoWriter = buffer
-		return globalSuite.run(t, description, specReporters, buffer, config.GinkgoConfig)
-	}
+	writer := GinkgoWriter.(*ginkgoWriter)
+	writer.setDirectToStdout(config.DefaultReporterConfig.Verbose)
+	return globalSuite.run(t, description, specReporters, writer, config.GinkgoConfig)
 }
 
 func buildDefaultReporter() Reporter {
@@ -178,6 +186,24 @@ func Fail(message string, callerSkip ...int) {
 		skip = callerSkip[0]
 	}
 	globalSuite.fail(message, skip)
+	panic(GINKGO_PANIC)
+}
+
+//GinkgoRecover should be deferred at the top of any spawned goroutine that (may) call `Fail`
+//Since Gomega assertions call fail, you should throw a `defer GinkgoRecover()` at the top of any goroutine that
+//calls out to Gomega
+//
+//Here's why: Ginkgo's `Fail` method records the failure and then panics to prevent
+//further assertions from running.  This panic must be recovered.  Ginkgo does this for you
+//if the panic originates in a Ginkgo node (an It, BeforeEach, etc...)
+//
+//Unfortunately, if a panic originates on a goroutine *launched* from one of these nodes there's no
+//way for Ginkgo to rescue the panic.  To do this, you must remember to `defer GinkgoRecover()` at the top of such a goroutine.
+func GinkgoRecover() {
+	e := recover()
+	if e != nil {
+		globalSuite.fail(fmt.Sprintf("Goroutine Panicked\n%#v", e), 1)
+	}
 }
 
 //Describe blocks allow you to organize your specs.  A Describe block can contain any number of

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/integration/integration_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo/integration/integration_suite_test.go
@@ -4,10 +4,16 @@ import (
 	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"testing"
 )
+
+var tmpDir string
 
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -19,4 +25,43 @@ func TestIntegration(t *testing.T) {
 	}
 
 	RunSpecs(t, "Integration Suite")
+}
+
+var _ = BeforeEach(func() {
+	var err error
+	tmpDir, err = ioutil.TempDir("", "ginkgo-run")
+	Ω(err).ShouldNot(HaveOccurred())
+})
+
+var _ = AfterEach(func() {
+	err := os.RemoveAll(tmpDir)
+	Ω(err).ShouldNot(HaveOccurred())
+})
+
+func tmpPath(destination string) string {
+	return filepath.Join(tmpDir, destination)
+}
+
+func copyIn(fixture string, destination string) {
+	err := os.MkdirAll(destination, 0777)
+	Ω(err).ShouldNot(HaveOccurred())
+
+	output, err := exec.Command("cp", "-r", filepath.Join("_fixtures", fixture)+"/", destination).CombinedOutput()
+	if !Ω(err).ShouldNot(HaveOccurred()) {
+		fmt.Println(output)
+	}
+}
+
+func runGinkgo(dir string, args ...string) (string, error) {
+	cmd := exec.Command("ginkgo", args...)
+	cmd.Dir = dir
+	cmd.Env = []string{}
+	for _, env := range os.Environ() {
+		if !strings.Contains(env, "GINKGO_REMOTE_REPORTING_SERVER") {
+			cmd.Env = append(cmd.Env, env)
+		}
+	}
+	output, err := cmd.CombinedOutput()
+	GinkgoWriter.Write(output)
+	return string(output), err
 }

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo_suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/ginkgo_suite_test.go
@@ -3,7 +3,6 @@ package ginkgo
 import (
 	. "github.com/onsi/gomega"
 
-	"io"
 	"math/rand"
 	"testing"
 )
@@ -37,14 +36,13 @@ func (fakeT *fakeTestingT) Fail() {
 
 type fakeGinkgoWriter struct {
 	didTruncate bool
-	wroteTo     io.Writer
+	didDump     bool
 }
 
-func (writer *fakeGinkgoWriter) Truncate(n int) {
+func (writer *fakeGinkgoWriter) Truncate() {
 	writer.didTruncate = true
 }
 
-func (writer *fakeGinkgoWriter) WriteTo(w io.Writer) (n int64, err error) {
-	writer.wroteTo = w
-	return 0, nil
+func (writer *fakeGinkgoWriter) DumpOut() {
+	writer.didDump = true
 }

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/measure_node.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/measure_node.go
@@ -25,9 +25,21 @@ func newMeasureNode(text string, body func(Benchmarker), flag flagType, codeLoca
 }
 
 func (node *measureNode) run() (outcome runOutcome, failure failureData) {
-	node.body(node.benchmarker)
+	defer func() {
+		if e := recover(); e != nil {
+			outcome = runOutcomePanicked
+			failure = failureData{
+				message:        "Test Panicked",
+				codeLocation:   types.GenerateCodeLocation(2),
+				forwardedPanic: e,
+			}
+		}
+	}()
 
-	return runOutcomeCompleted, failureData{}
+	node.body(node.benchmarker)
+	outcome = runOutcomeCompleted
+
+	return
 }
 
 func (node *measureNode) measurementsReport() map[string]*types.ExampleMeasurement {

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/suite.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/suite.go
@@ -4,7 +4,6 @@ import (
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/types"
 
-	"io"
 	"math/rand"
 	"time"
 )
@@ -21,11 +20,6 @@ type suite struct {
 	exampleCollection *exampleCollection
 }
 
-type ginkgoWriter interface {
-	Truncate(n int)
-	WriteTo(w io.Writer) (n int64, err error)
-}
-
 func newSuite() *suite {
 	topLevelContainer := newContainerNode("[Top Level]", flagTypeNone, types.CodeLocation{})
 
@@ -35,7 +29,7 @@ func newSuite() *suite {
 	}
 }
 
-func (suite *suite) run(t GinkgoTestingT, description string, reporters []Reporter, writer ginkgoWriter, config config.GinkgoConfigType) bool {
+func (suite *suite) run(t GinkgoTestingT, description string, reporters []Reporter, writer ginkgoWriterInterface, config config.GinkgoConfigType) bool {
 	r := rand.New(rand.NewSource(config.RandomSeed))
 	suite.topLevelContainer.shuffle(r)
 

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/suite_test.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/suite_test.go
@@ -15,9 +15,11 @@ func init() {
 			specSuite *suite
 			fakeT     *fakeTestingT
 			fakeR     *reporters.FakeReporter
+			writer    *fakeGinkgoWriter
 		)
 
 		BeforeEach(func() {
+			writer = &fakeGinkgoWriter{}
 			fakeT = &fakeTestingT{}
 			fakeR = reporters.NewFakeReporter()
 			specSuite = newSuite()
@@ -72,7 +74,7 @@ func init() {
 			})
 
 			JustBeforeEach(func() {
-				runResult = specSuite.run(fakeT, "suite description", []Reporter{fakeR}, nil, config.GinkgoConfigType{
+				runResult = specSuite.run(fakeT, "suite description", []Reporter{fakeR}, writer, config.GinkgoConfigType{
 					RandomSeed:        randomSeed,
 					RandomizeAllSpecs: randomizeAllSpecs,
 					FocusString:       focusString,


### PR DESCRIPTION
Upgrade ginkgo in order to pick up 736acf4afbc1fff096f59fb899163b602edec924.

This enables measurements test failures in goroutines to fail the suite.
