### PR TITLE
Avoid receive starvation

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -114,6 +114,11 @@ func (s *WardenServer) trackStopping() {
 		select {
 		case stopping = <-s.setStopping:
 		case s.stopping <- stopping:
+			// Avoid receive starvation.
+			select {
+			case stopping = <-s.setStopping:
+			default:
+			}
 		}
 	}
 }


### PR DESCRIPTION
Although Go chooses between multiple select cases which are ready to
communicate, it does not guarantee fairness. So, on a busy system,
there is no guarantee that the WardenServer trackStopping method will
receive from s.setStopping if it can always send to s.stopping.

So check s.setStopping (without blocking) after each successful send
to s.stopping.

The fix is strictly necessary from a theoretical perspective, but extremely unlikely to be necessary in practice. The real value of the fix is to improve Go concurrency style.
