### PR TITLE
Make public the Listen() function for garden server.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -148,7 +148,7 @@ func New(
 }
 
 func (s *GardenServer) ListenAndServe() error {
-	listener, err := s.listen()
+	listener, err := s.Listen()
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (s *GardenServer) Start() error {
 		return err
 	}
 
-	listener, err := s.listen()
+	listener, err := s.Listen()
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (s *GardenServer) SetupBomberman() error {
 	return nil
 }
 
-func (s *GardenServer) listen() (net.Listener, error) {
+func (s *GardenServer) Listen() (net.Listener, error) {
 	if err := s.removeExistingSocket(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows callers to Listen() prior to serving, for cases where we want the socket open/available prior to responding to requests. Primarily used for creating socket files that the healtchecker will be able to mount in BPM while waiting for gdn to finish cleaning up pre-existing containers.