### PR TITLE
changed ContainerNetworkStat to a pointer

### DIFF
--- a/container.go
+++ b/container.go
@@ -240,7 +240,7 @@ type Metrics struct {
 	MemoryStat     ContainerMemoryStat
 	CPUStat        ContainerCPUStat
 	DiskStat       ContainerDiskStat
-	NetworkStat    ContainerNetworkStat
+	NetworkStat    *ContainerNetworkStat
 	PidStat        ContainerPidStat
 	Age            time.Duration
 	CPUEntitlement uint64


### PR DESCRIPTION
* Related to https://github.com/cloudfoundry/cf-networking-release/issues/64
* Changed `ContainerNetworkStat` to a pointer to differentiate between empty and zero values
* Required for https://github.com/cloudfoundry/guardian/pull/417#issuecomment-1662369990 and https://github.com/cloudfoundry/guardian/pull/417#discussion_r1282064432
* Allows a backwards compatible implementation and avoids sending non-existent metrics for the windows implementation in the [executor](https://github.com/cloudfoundry/executor/pull/83/files#diff-2c65e59bed158ee71bb766bd5fe11df9a6ce1ee257186597e99f785577eb1eb8R363-R367).