### PR TITLE
Fix gosec issue for file permissions 

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -225,6 +225,7 @@ func (s *GardenServer) Listen() (net.Listener, error) {
 		// deployments, garden server and diego rep always run as different users.
 		// https://www.pivotaltracker.com/story/show/151245015 addresses this
 		// issue.
+		// #nosec G302
 		if err := os.Chmod(s.listenAddr, 0777); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
ignore gosec g302 for server/server.go, as we need the socket file tovbe world writable for diego->garden communication


Backward Compatibility
---------------
Breaking Change? no