### PR TITLE
Make container window sizes uint16 to match what guardian now expects

### DIFF
--- a/container.go
+++ b/container.go
@@ -176,8 +176,8 @@ type TTYSpec struct {
 }
 
 type WindowSize struct {
-	Columns int `json:"columns,omitempty"`
-	Rows    int `json:"rows,omitempty"`
+	Columns uint16 `json:"columns,omitempty"`
+	Rows    uint16 `json:"rows,omitempty"`
 }
 
 type ProcessIO struct {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------



Backward Compatibility
---------------
Breaking Change? no