### PR TITLE
Move to docs dir instead

### DIFF
--- a/docs/garden-api.md
+++ b/docs/garden-api.md
@@ -1,3 +1,11 @@
+---
+title: API Guide
+expires_at: never
+tags: [ garden-runc-release, garden ]
+---
+
+# API Guide
+
 # Ping
 Example: GET /ping
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Move to docs dir instead so that sync-readme job can read the file


Backward Compatibility
---------------
Breaking Change? **No**
