### PR TITLE
[IPv6] icmpv6 support

### DIFF
--- a/net_out_rule.go
+++ b/net_out_rule.go
@@ -26,6 +26,7 @@ const (
 	ProtocolTCP
 	ProtocolUDP
 	ProtocolICMP
+	ProtocolICMPv6
 )
 
 type IPRange struct {

--- a/server/request_handling_test.go
+++ b/server/request_handling_test.go
@@ -1383,6 +1383,16 @@ var _ = Describe("When a client connects", func() {
 					})
 				})
 
+				Context("as ICMPv6", func() {
+					It("permits ICMPv6 traffic", func() {
+						Expect(container.NetOut(garden.NetOutRule{
+							Protocol: garden.ProtocolICMPv6,
+						})).To(Succeed())
+						rule := fakeContainer.NetOutArgsForCall(0)
+						Expect(rule.Protocol).To(Equal(garden.ProtocolICMPv6))
+					})
+				})
+
 				Context("as ALL", func() {
 					It("permits ALL traffic", func() {
 						Expect(container.NetOut(garden.NetOutRule{


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add icmpv6 protocol support in NetOutRule


Backward Compatibility
---------------
Breaking Change? **No**
